### PR TITLE
fix(rob): update amuctrlbuffer redirect condition corresponding to ROB

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/AMUCtrlBuffer.scala
+++ b/src/main/scala/xiangshan/backend/rob/AMUCtrlBuffer.scala
@@ -216,11 +216,11 @@ class AmuCtrlBuffer()(implicit override val p: Parameters, val params: BackendPa
 
   // Redirect (Sync with outer ROB)
   for (i <- 0 until RobSize) {
-    val needFlush = io.redirect.valid &&
-      Mux((io.redirect.end > io.redirect.begin) && !io.redirect.all,
+    val needFlush = io.redirect.valid && (Mux(
+      (io.redirect.end > io.redirect.begin),
         (i.U > io.redirect.begin) && (i.U < io.redirect.end),
         (i.U > io.redirect.begin) || (i.U < io.redirect.end)
-    )
+      ) || io.redirect.all)
 
     when (needFlush) {
       amuCtrlEntries(i) := AmuCtrlEntry.zero


### PR DESCRIPTION
When the ROB is full and a flush instruction resides at physical head index 0, the ROB is fully cleared according to redirectAll. However, the rollback range of the AmuCtrlBuffer degenerates into an empty set, causing all stale entries to be retained. This ultimately results in permanent back-pressure on the recovery path.

Root Cause:​

The ROB redirection conditions were modified without corresponding updates to the AmuCtrlBuffer logic.