### PR TITLE
fix(rob): Avoid undefined behavior of PriorityEncoder

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/AMUCtrlBuffer.scala
+++ b/src/main/scala/xiangshan/backend/rob/AMUCtrlBuffer.scala
@@ -330,7 +330,7 @@ class AmuCtrlBuffer()(implicit override val p: Parameters, val params: BackendPa
   }
 
   val deqCondSeq = deqEntries.map(x => ~x.canDeq)
-  val deqCount = PriorityEncoder(deqCondSeq)
+  val deqCount = PriorityEncoder(deqCondSeq :+ true.B)
   // Update deqPtr and invalidate entries
   deqPtr := deqPtr + deqCount
   for (i <- 0 until CommitWidth) {


### PR DESCRIPTION
When deqCondSeq is all zeros, the output of PriorityEncoder is undefined. Therefore, add a sentinel bit.