### PR TITLE
build(elaboration): add a parameter cache to speed up the elaboration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,11 @@ ifeq ($(DISABLE_XMR),1)
 COMMON_EXTRA_ARGS += --disable-xmr
 endif
 
+# disable the tile-level CDE parameter cache
+ifeq ($(CACHED_PARAM_DISABLE),1)
+COMMON_EXTRA_ARGS += --disable-cached-parameters
+endif
+
 # configuration from yaml file
 ifneq ($(YAML_CONFIG),)
 COMMON_EXTRA_ARGS += --yaml-config $(YAML_CONFIG)

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -238,6 +238,10 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(EnableXMR = false)
           }), tail)
+        case "--disable-cached-parameters" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case CachedParameterKey => false
+          }), tail)
         case "--yaml-config" :: yamlFile :: tail =>
           nextOption(YamlParser.parseYaml(config, yamlFile), tail)
         case option :: tail =>

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -102,10 +102,10 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
   println(s"FPGASoC cores: $NumCores banks: $L3NBanks block size: $L3BlockSize bus size: $L3OuterBusWidth")
 
   val core_with_l2 = tiles.map(coreParams =>
-    LazyModule(new XSTile()(p.alter((site, here, up) => {
+    LazyModule(new XSTile()(XSCachedParametersOptional(p(CachedParameterKey), p.alter((site, here, up) => {
       case XSCoreParamsKey => coreParams
       case PerfCounterOptionsKey => up(PerfCounterOptionsKey).copy(perfDBHartID = coreParams.HartId)
-    })))
+    }))))
   )
 
   val chi_llcBridge_opt = Option.when(isOpenLLC)(

--- a/src/main/scala/top/XSCachedParameters.scala
+++ b/src/main/scala/top/XSCachedParameters.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Beijing Institute of Open Source Chip (BOSC)
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package top
+
+import org.chipsalliance.cde.config.{Field, Parameters, View}
+
+import scala.collection.mutable
+
+private[top] object XSCachedParameters {
+  def cached(underlying: Parameters): Parameters = new CachedParameters(underlying)
+  def apply(underlying: Parameters): Parameters = cached(underlying)
+
+  private class CachedParameters(underlying: Parameters) extends Parameters {
+    private val cache = mutable.HashMap.empty[Field[_], Option[Any]]
+
+    override def find[T](key: Field[T]): Option[T] =
+      cache.get(key) match {
+        case Some(value) =>
+          value.asInstanceOf[Option[T]]
+
+        case None =>
+          val value = underlying.lift(key)
+          cache(key) = value
+          value
+      }
+
+    override def chain[T](
+      site:  View,
+      here:  View,
+      up:    View,
+      pname: Field[T]
+    ): Option[T] = {
+      throw new Exception("The XSCachedParameters is frozen thus cannot participate in alter/orElse")
+    }
+  }
+}
+
+private[top] object XSCachedParametersOptional {
+  def apply(enable: Boolean, p: Parameters): Parameters = if (enable) XSCachedParameters(p) else p
+  def apply(enable: Option[Boolean], p: Parameters): Parameters = enable match {
+    case Some(value) => apply(value, p)
+    case None        => p
+  }
+}
+
+private[top] case object CachedParameterKey extends Field[Boolean](true)

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -197,10 +197,10 @@ trait HasCoreLowPowerImp[+L <: HasXSTile] { this: BaseXSSocImp with HasXSTileCHI
 trait HasXSTile { this: BaseXSSoc =>
 
   // xstile
-  val core_with_l2 = LazyModule(new XSTileWrap()(p.alter((site, here, up) => {
+  val core_with_l2 = LazyModule(new XSTileWrap()(XSCachedParametersOptional(p(CachedParameterKey), p.alter((site, here, up) => {
     case XSCoreParamsKey => tiles.head
     case PerfCounterOptionsKey => up(PerfCounterOptionsKey).copy(perfDBHartID = tiles.head.HartId)
-  })))
+  }))))
   // interrupts
   val clintIntNode = Option.when(!UsePrivateClint)(IntSourceNode(IntSourcePortSimple(1, 1, 2)))
   val debugIntNode = IntSourceNode(IntSourcePortSimple(1, 1, 1))

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -227,6 +227,9 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       val chi = Option.when(isOpenLLC)(new PortIO)
       val decoupledCHI = Option.when(isZhuJiang)(
         new DecoupledPortIO()(p.alter((_, _, _) => {
+          case CHIIssue => p(CHIIssue)
+          case CHIAddrWidthKey => p(CHIAddrWidthKey)
+          case NonSecureKey => p(NonSecureKey)
           case CHIDataCheckKey => "none"
           case CHIPoisonKey => false
         }))

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -28,7 +28,7 @@ import system.HasSoCParameter
 import top.{ArgParser, BusPerfMonitor, Generator}
 import utility._
 import utility.sram.SramBroadcastBundle
-import xscache.chi.{CHIDataCheckKey, CHIPoisonKey, DecoupledPortIO, PortIO}
+import xscache.chi.{CHIAddrWidthKey, CHIDataCheckKey, CHIIssue, CHIPoisonKey, DecoupledPortIO, NonSecureKey, PortIO}
 import xiangshan.backend.trace.TraceCoreInterface
 import xiangshan.backend.fu.matrix._
 import xiangshan.backend.fu.matrix.Bundles._
@@ -137,6 +137,9 @@ class XSTile()(implicit p: Parameters) extends LazyModule
       val chi = Option.when(isOpenLLC)(new PortIO)
       val decoupledCHI = Option.when(isZhuJiang)(
         new DecoupledPortIO()(p.alter((_, _, _) => {
+          case CHIIssue => p(CHIIssue)
+          case CHIAddrWidthKey => p(CHIAddrWidthKey)
+          case NonSecureKey => p(NonSecureKey)
           case CHIDataCheckKey => "none"
           case CHIPoisonKey => false
         }))

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -25,7 +25,7 @@ import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import system.HasSoCParameter
-import xscache.chi.{AsyncPortIO, CHIAsyncBridgeSource, CHIDataCheckKey, CHIPoisonKey, DecoupledPortIO, PortIO}
+import xscache.chi.{AsyncPortIO, CHIAddrWidthKey, CHIAsyncBridgeSource, CHIDataCheckKey, CHIIssue, CHIPoisonKey, DecoupledPortIO, NonSecureKey, PortIO}
 import utility.sram.SramBroadcastBundle
 import utility.{DFTResetSignals, IntBuffer, ResetGen}
 import xiangshan.backend.trace.TraceCoreInterface
@@ -93,6 +93,9 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
       })
       val decoupledCHI = Option.when(isZhuJiang)(
         new DecoupledPortIO()(p.alter((_, _, _) => {
+          case CHIIssue => p(CHIIssue)
+          case CHIAddrWidthKey => p(CHIAddrWidthKey)
+          case NonSecureKey => p(NonSecureKey)
           case CHIDataCheckKey => "none"
           case CHIPoisonKey => false
         }))


### PR DESCRIPTION
This PR introduces a tile-level CDE parameter cache to eliminate repeated parameter lookups during elaboration. Using `DefaultMatrixConfig + ZhuJiang + 1 core`, six warmed-up, counterbalanced `AB/BA` measurement pairs show that the median end-to-end `xiangshan.runMain` time decreases from **595.350 s to 398.239 s**, a **33.108% reduction**. The mean paired reduction is **33.187%**, with a 95% confidence interval of **[32.498%, 33.876%]**. The Chisel-to-FIR phase decreases from **316.695 s to 119.159 s**, a **62.374% reduction**, while the firtool phase remains effectively unchanged (278.575 s vs. 278.951 s), confirming that the improvement comes entirely from parameter caching. A separate 1 ms profiler run shows that CDE queries account for **34.475%** of the elaboration main thread’s wall time, consistent with the approximately 197 seconds saved and with the 35.16% query share and 33% end-to-end improvement reported in upstream XiangShan PR #6336. All 12 successful runs produced 2,268 byte-identical FIR/SystemVerilog files, confirming that the optimization does not change the generated RTL. An earlier single-run result of 12.8% was excluded because an approximately 95-second firtool timing imbalance distorted the end-to-end comparison.