### PR TITLE
fix(build): isolate generated artifacts by BUILD_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@
 # See the Mulan PSL v2 for more details.
 #***************************************************************************************
 
-BUILD_DIR = ./build
+BUILD_DIR ?= ./build
+GENERATED_DIR ?= $(abspath $(BUILD_DIR))
 RTL_DIR = $(BUILD_DIR)/rtl
 
 # import docker support
@@ -286,7 +287,7 @@ comp:
 
 $(TOP_V): $(SCALA_FILE)
 	mkdir -p $(@D)
-	$(TIME_CMD) mill -i $(MILL_BUILD_ARGS) xiangshan.runMain $(FPGATOP)   \
+	GENERATED_DIR="$(GENERATED_DIR)" $(TIME_CMD) mill -i $(MILL_BUILD_ARGS) xiangshan.runMain $(FPGATOP)   \
 		--target-dir $(@D) --config $(CONFIG) --issue $(ISSUE) $(FPGA_MEM_ARGS)		\
 		--num-cores $(NUM_CORES) $(TOPMAIN_ARGS)
 ifeq ($(CHISEL_TARGET),systemverilog)
@@ -301,7 +302,7 @@ $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	mkdir -p $(@D)
 	@echo -e "\n[mill] Generating Verilog files..." > $(TIMELOG)
 	@date -R | tee -a $(TIMELOG)
-	$(TIME_CMD) mill -i $(MILL_BUILD_ARGS) xiangshan.test.runMain $(SIMTOP)    \
+	GENERATED_DIR="$(GENERATED_DIR)" $(TIME_CMD) mill -i $(MILL_BUILD_ARGS) xiangshan.test.runMain $(SIMTOP)    \
 		--target-dir $(@D) --config $(CONFIG) --issue $(ISSUE) $(SIM_MEM_ARGS)		\
 		--num-cores $(NUM_CORES) $(SIM_ARGS) --full-stacktrace
 ifeq ($(CHISEL_TARGET),systemverilog)

--- a/src/main/scala/top/GeneratedFileDir.scala
+++ b/src/main/scala/top/GeneratedFileDir.scala
@@ -1,0 +1,5 @@
+package top
+
+object GeneratedFileDir {
+  def value: String = sys.env.getOrElse("GENERATED_DIR", "./build")
+}

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -543,5 +543,5 @@ object TopMain extends App {
     }
   }
 
-  FileRegisters.write(fileDir = "./build", filePrefix = "XSTop.")
+  FileRegisters.write(fileDir = GeneratedFileDir.value, filePrefix = "XSTop.")
 }

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -571,6 +571,6 @@ object XSNoCDiffTopChecker {
         |
         |endmodule
       """.stripMargin
-    FileRegisters.writeOutputFile("./build", "XSDiffTopChecker.sv", verilog)
+    FileRegisters.writeOutputFile(GeneratedFileDir.value, "XSDiffTopChecker.sv", verilog)
   }
 }

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -124,5 +124,5 @@ object XiangShanSim extends App {
   // tools: write cpp files
   ChiselDB.addToFileRegisters
   Constantin.addToFileRegisters
-  FileRegisters.write(fileDir = "./build")
+  FileRegisters.write(fileDir = GeneratedFileDir.value)
 }


### PR DESCRIPTION
## Summary

- derive `GENERATED_DIR` from `BUILD_DIR`
- route Chisel and DiffTest generated artifacts into the selected build directory
- preserve the existing `./build` fallback for direct Mill invocations
- update the DiffTest gitlink to the generated-artifact isolation change

## Problem

The Verilator flow supports custom `BUILD_DIR` values for RTL and emulator outputs, but Chisel and DiffTest sidecar files were still written below `<NOOP_HOME>/build`.

When two configurations are built from the same `NOOP_HOME`, for example `DefaultConfig` and `MinimalConfig`, or `DefaultMatrixConfig` with different LLC settings, they can overwrite shared files such as `DifftestMacros.svh`, `chisel_db.cpp`, `constantin.cpp`, and `perfCCT.cpp`.

This makes parallel configuration builds from the same XSAI source tree unreliable even when they use different `BUILD_DIR` values.

## Dependency

Depends on [OpenXiangShan/difftest#947](https://github.com/OpenXiangShan/difftest/pull/947).

## Scope

This changes generated artifact placement only. XSAI and DiffTest runtime behavior is unchanged.
