### PR TITLE
fix(issue): wake up delayed Mx operands

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -544,7 +544,7 @@ object EntryBundles extends HasCircularQueuePtrHelper {
   def EnqDelayWakeupConnect(enqDelayIn: EnqDelayInBundle, enqDelayOut: EnqDelayOutBundle, status: Status, delay: Int)(implicit p: Parameters, params: IssueBlockParams) = {
     enqDelayOut.srcWakeUpByWB.zipWithIndex.foreach { case (wakeup, i) =>
       wakeup := enqDelayIn.wakeUpFromWB.map{ x =>
-        if (params.isMfSchd) {
+        if (params.isMfSchd || params.numMxSrc != 0) {
           x.bits.wakeUp(Seq((status.srcStatus(i).psrc, status.srcStatus(i).srcType)), x.valid).head
         } else {
           if (i == 3)


### PR DESCRIPTION
## Summary

- Fix delayed writeback wakeup for issue queues carrying Mx operands.
- MLSU uses `[Int, Int, Mx, Mx]` sources. `EnqDelayWakeupConnect` previously treated source slot 3 as V0, so an Mx writeback in the enqueue-delay window could be missed and permanently block an MLS instruction.
- Route issue blocks with Mx sources through the existing type-aware generic wakeup path. V0/VL-specific handling for issue blocks without Mx sources is unchanged.

## Scope

- XSAI backend issue queue only.
- No CUTE, AMUCtrl, ISA, NEMU, or software changes.

## Validation

- BF16 bare-metal GEMM, `M=256, N=256, K=32`:
  - Output verifier passed.
  - Executed 4 `mmacc` operations and 4 C stores.
  - RTL reached `HIT GOOD TRAP`.
- Difftest against the NEMU reference passed with no mismatch.