### PR TITLE
refactor(backend): remove unused matrix commit interfaces

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -263,11 +263,9 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   memBlock.io.ooo_to_mem.tlbCsr := backend.io.mem.tlbCsr
   memBlock.io.ooo_to_mem.lsqio.lcommit          := backend.io.mem.robLsqIO.lcommit
   memBlock.io.ooo_to_mem.lsqio.scommit          := backend.io.mem.robLsqIO.scommit
-  memBlock.io.ooo_to_mem.lsqio.mcommit          := backend.io.mem.robLsqIO.mcommit
   memBlock.io.ooo_to_mem.lsqio.pendingMMIOld    := backend.io.mem.robLsqIO.pendingMMIOld
   memBlock.io.ooo_to_mem.lsqio.pendingld        := backend.io.mem.robLsqIO.pendingld
   memBlock.io.ooo_to_mem.lsqio.pendingst        := backend.io.mem.robLsqIO.pendingst
-  memBlock.io.ooo_to_mem.lsqio.pendingmls       := backend.io.mem.robLsqIO.pendingmls
   memBlock.io.ooo_to_mem.lsqio.pendingVst       := backend.io.mem.robLsqIO.pendingVst
   memBlock.io.ooo_to_mem.lsqio.commit           := backend.io.mem.robLsqIO.commit
   memBlock.io.ooo_to_mem.lsqio.pendingPtr       := backend.io.mem.robLsqIO.pendingPtr

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -476,14 +476,11 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   memScheduler.io.mxWriteBackDelayed.foreach(_ := mxWriteBackDelayed.get)
   memScheduler.io.fromMem.get.scommit := io.mem.sqDeq
   memScheduler.io.fromMem.get.lcommit := io.mem.lqDeq
-  memScheduler.io.fromMem.get.mcommit.foreach(_ := io.mem.mlsqDeq.get)
   memScheduler.io.fromMem.get.wakeup := io.mem.wakeup
   memScheduler.io.fromMem.get.sqDeqPtr := io.mem.sqDeqPtr
   memScheduler.io.fromMem.get.lqDeqPtr := io.mem.lqDeqPtr
-  memScheduler.io.fromMem.get.mlsqDeqPtr.foreach(_ := io.mem.mlsqDeqPtr.get)
   memScheduler.io.fromMem.get.sqCancelCnt := io.mem.sqCancelCnt
   memScheduler.io.fromMem.get.lqCancelCnt := io.mem.lqCancelCnt
-  memScheduler.io.fromMem.get.mlsqCancelCnt.foreach(_ := io.mem.mlsqCancelCnt.get)
   memScheduler.io.fromMem.get.stIssuePtr := io.mem.stIssuePtr
   require(memScheduler.io.fromMem.get.memWaitUpdateReq.robIdx.length == io.mem.stIn.length)
   memScheduler.io.fromMem.get.memWaitUpdateReq.robIdx.zip(io.mem.stIn).foreach { case (sink, source) =>

--- a/src/main/scala/xiangshan/backend/issue/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/issue/Scheduler.scala
@@ -13,7 +13,6 @@ import xiangshan.backend.datapath.WbConfig._
 import xiangshan.backend.fu.FuType
 import xiangshan.backend.regfile.RfWritePortWithConfig
 import xiangshan.mem.Bundles.MemWaitUpdateReqBundle
-import xiangshan.mem.{LsqEnqCtrl, LsqEnqIO, SqPtr, LqPtr, MlsqPtr}
 import xiangshan.backend.datapath.WbConfig.V0WB
 import xiangshan.backend.regfile.VlPregParams
 import xiangshan.backend.regcache.RegCacheTagTable
@@ -142,15 +141,12 @@ class SchedulerIO()(implicit params: SchdBlockParams, p: Parameters) extends XSB
     val stIssuePtr = Input(new SqPtr())
     val lcommit = Input(UInt(log2Up(CommitWidth + 1).W))
     val scommit = Input(UInt(log2Ceil(EnsbufferWidth + 1).W)) // connected to `memBlock.io.sqDeq` instead of ROB
-    val mcommit = OptionWrapper(HasMatrixExtension, Input(UInt(log2Up(CommitWidth + 1).W)))
     val wakeup = Vec(params.LdWakeupCnt, Flipped(Valid(new DynInst)))
     val lqDeqPtr = Input(new LqPtr)
     val sqDeqPtr = Input(new SqPtr)
-    val mlsqDeqPtr = OptionWrapper(HasMatrixExtension, Input(new MlsqPtr))
     // from lsq
     val lqCancelCnt = Input(UInt(log2Up(LoadQueueSize + 1).W))
     val sqCancelCnt = Input(UInt(log2Up(StoreQueueSize + 1).W))
-    val mlsqCancelCnt = OptionWrapper(HasMatrixExtension, Input(UInt(log2Up(MlsQueueSize + 1).W)))
     val memWaitUpdateReq = Flipped(new MemWaitUpdateReqBundle)
   }) else None
   val toMem = if (params.isMemSchd) Some(new Bundle {

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -893,16 +893,13 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val ldCommitVec = VecInit((0 until CommitWidth).map(i => io.commits.commitValid(i) && io.commits.info(i).commitType === CommitType.LOAD))
   // TODO: Check if meet the require that only set scommit when commit scala store uop
   val stCommitVec = VecInit((0 until CommitWidth).map(i => io.commits.commitValid(i) && io.commits.info(i).commitType === CommitType.STORE && !robEntries(deqPtrVec(i).value).vls ))
-  val mlsCommitVec = VecInit((0 until CommitWidth).map(i => io.commits.commitValid(i) && io.commits.info(i).commitType === CommitType.MLS))
   io.lsq.lcommit := RegNext(Mux(io.commits.isCommit, PopCount(ldCommitVec), 0.U))
   io.lsq.scommit := RegNext(Mux(io.commits.isCommit, PopCount(stCommitVec), 0.U))
-  io.lsq.mcommit := RegNext(Mux(io.commits.isCommit, PopCount(mlsCommitVec), 0.U))
   // indicate a pending load or store
   io.lsq.pendingMMIOld := RegNext(io.commits.isCommit && io.commits.info(0).commitType === CommitType.LOAD && deqPtrEntryValid && deqPtrEntry.mmio)
   io.lsq.pendingld := RegNext(io.commits.isCommit && io.commits.info(0).commitType === CommitType.LOAD && deqPtrEntryValid)
   // TODO: Check if need deassert pendingst when it is vst
   io.lsq.pendingst := RegNext(io.commits.isCommit && io.commits.info(0).commitType === CommitType.STORE && deqPtrEntryValid)
-  io.lsq.pendingmls := RegNext(io.commits.isCommit && io.commits.info(0).commitType === CommitType.MLS && deqPtrEntryValid)
   // TODO: Check if set correctly when vector store is at the head of ROB
   io.lsq.pendingVst := RegNext(io.commits.isCommit && io.commits.info(0).commitType === CommitType.STORE && deqPtrEntryValid && deqPtrEntry.vls)
   io.lsq.commit := RegNext(io.commits.isCommit && io.commits.commitValid(0))

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -263,11 +263,9 @@ class RobCSRIO(implicit p: Parameters) extends XSBundle {
 class RobLsqIO(implicit p: Parameters) extends XSBundle {
   val lcommit = Output(UInt(log2Up(CommitWidth + 1).W))
   val scommit = Output(UInt(log2Up(CommitWidth + 1).W))
-  val mcommit = Output(UInt(log2Up(CommitWidth + 1).W))
   val pendingMMIOld = Output(Bool())
   val pendingld = Output(Bool())
   val pendingst = Output(Bool())
-  val pendingmls = Output(Bool())
   // set when vector store at the head of ROB
   val pendingVst = Output(Bool())
   val commit = Output(Bool())

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -100,11 +100,9 @@ class ooo_to_mem(implicit p: Parameters) extends MemBlockBundle {
   val lsqio = new Bundle {
     val lcommit = Input(UInt(log2Up(CommitWidth + 1).W))
     val scommit = Input(UInt(log2Up(CommitWidth + 1).W))
-    val mcommit = Input(UInt(log2Up(CommitWidth + 1).W))
     val pendingMMIOld = Input(Bool())
     val pendingld = Input(Bool())
     val pendingst = Input(Bool())
-    val pendingmls = Input(Bool())
     val pendingVst = Input(Bool())
     val commit = Input(Bool())
     val pendingPtr = Input(new RobPtr)
@@ -1218,11 +1216,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   loadMisalignBuffer.io.redirect                <> redirect
   loadMisalignBuffer.io.rob.lcommit             := io.ooo_to_mem.lsqio.lcommit
   loadMisalignBuffer.io.rob.scommit             := io.ooo_to_mem.lsqio.scommit
-  loadMisalignBuffer.io.rob.mcommit             := io.ooo_to_mem.lsqio.mcommit
   loadMisalignBuffer.io.rob.pendingMMIOld       := io.ooo_to_mem.lsqio.pendingMMIOld
   loadMisalignBuffer.io.rob.pendingld           := io.ooo_to_mem.lsqio.pendingld
   loadMisalignBuffer.io.rob.pendingst           := io.ooo_to_mem.lsqio.pendingst
-  loadMisalignBuffer.io.rob.pendingmls          := io.ooo_to_mem.lsqio.pendingmls
   loadMisalignBuffer.io.rob.pendingVst          := io.ooo_to_mem.lsqio.pendingVst
   loadMisalignBuffer.io.rob.commit              := io.ooo_to_mem.lsqio.commit
   loadMisalignBuffer.io.rob.pendingPtr          := io.ooo_to_mem.lsqio.pendingPtr
@@ -1234,11 +1230,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   storeMisalignBuffer.io.redirect               <> redirect
   storeMisalignBuffer.io.rob.lcommit            := io.ooo_to_mem.lsqio.lcommit
   storeMisalignBuffer.io.rob.scommit            := io.ooo_to_mem.lsqio.scommit
-  storeMisalignBuffer.io.rob.mcommit            := io.ooo_to_mem.lsqio.mcommit
   storeMisalignBuffer.io.rob.pendingMMIOld      := io.ooo_to_mem.lsqio.pendingMMIOld
   storeMisalignBuffer.io.rob.pendingld          := io.ooo_to_mem.lsqio.pendingld
   storeMisalignBuffer.io.rob.pendingst          := io.ooo_to_mem.lsqio.pendingst
-  storeMisalignBuffer.io.rob.pendingmls         := io.ooo_to_mem.lsqio.pendingmls
   storeMisalignBuffer.io.rob.pendingVst         := io.ooo_to_mem.lsqio.pendingVst
   storeMisalignBuffer.io.rob.commit             := io.ooo_to_mem.lsqio.commit
   storeMisalignBuffer.io.rob.pendingPtr         := io.ooo_to_mem.lsqio.pendingPtr
@@ -1445,11 +1439,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   io.mem_to_ooo.lsqio.uop        := lsq.io.rob.uop
   lsq.io.rob.lcommit             := io.ooo_to_mem.lsqio.lcommit
   lsq.io.rob.scommit             := io.ooo_to_mem.lsqio.scommit
-  lsq.io.rob.mcommit             := io.ooo_to_mem.lsqio.mcommit
   lsq.io.rob.pendingMMIOld       := io.ooo_to_mem.lsqio.pendingMMIOld
   lsq.io.rob.pendingld           := io.ooo_to_mem.lsqio.pendingld
   lsq.io.rob.pendingst           := io.ooo_to_mem.lsqio.pendingst
-  lsq.io.rob.pendingmls          := io.ooo_to_mem.lsqio.pendingmls
   lsq.io.rob.pendingVst          := io.ooo_to_mem.lsqio.pendingVst
   lsq.io.rob.commit              := io.ooo_to_mem.lsqio.commit
   lsq.io.rob.pendingPtr          := io.ooo_to_mem.lsqio.pendingPtr

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -171,7 +171,6 @@ package object xiangshan {
     def BRANCH = "b001".U  // branch
     def LOAD   = "b010".U  // load
     def STORE  = "b011".U  // store
-    def MLS    = "b100".U  // mls
 
     def apply() = UInt(3.W)
     def isFused(commitType: UInt): Bool = commitType(2)


### PR DESCRIPTION
## Summary

Remove obsolete matrix commit bookkeeping and scheduler feedback interfaces
from the XSAI backend.

- Remove `CommitType.MLS` and ROB-side `mlsCommitVec` / `pendingmls`.
- Remove `mcommit` and `pendingmls` forwarding through `RobLsqIO`,
  `XSCore`, and `MemBlock`.
- Remove unused `mcommit`, `mlsqDeqPtr`, and `mlsqCancelCnt` fields from
  `SchedulerIO.fromMem` and their Backend wiring.
- Preserve the active MLSQ dequeue and dispatch-side `mcommit` path used for
  MLSQ capacity accounting.

## Scope

- Workstream: RTL / XSAI backend
- Matrix-related interface cleanup only.
- Scalar load/store commit interfaces are unchanged.
- No functional logic was added.
- This PR contains the XSAI submodule changes; the parent repository gitlink
  update is separate.