### PR TITLE
ci: parallelize emu and nightly regressions

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CI_HOME: /nfs/home/ci-runner/xsai-emu/${{ github.run_number }}
+  EMU_HOME: /nfs/home/ci-runner/xsai-emu/${{ github.run_number }}/default-matrix
 
 jobs:
   changes: # Changes Detection
@@ -94,13 +95,15 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --numa --ci linux-hello-opensbi 2> perf.log
           cat perf.log | sort
 
-  emu-xsai-basics:
+  build-xsai-emu:
     runs-on: bosc
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' }}
+    outputs:
+      cluster: ${{ steps.save.outputs.cluster }}
     continue-on-error: false
     timeout-minutes: 900
-    name: EMU - XSAI Basics
+    name: EMU - Build DefaultMatrixConfig
     steps:
       - uses: actions/checkout@v7
         with:
@@ -108,14 +111,9 @@ jobs:
           submodules: true
       - name: set env
         run: |
-          JOB_HOME="${CI_HOME}/basics"
           echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
-          echo "PERF_HOME=${JOB_HOME}" >> $GITHUB_ENV
-          echo "WAVE_HOME=${JOB_HOME}" >> $GITHUB_ENV
-          echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
-          mkdir -p "${JOB_HOME}"
       - name: Initialize submodules
         run: make init-force
       - name: clean up
@@ -130,6 +128,49 @@ jobs:
             $GITHUB_WORKSPACE/difftest/verilator.mk
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build --threads 8 \
             --config DefaultMatrixConfig --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata --trace-fst
+      - name: Save artifact
+        id: save
+        run: |
+          mkdir -p "${EMU_HOME}"
+          cp -L "${GITHUB_WORKSPACE}/build/emu" "${EMU_HOME}/emu"
+          if [[ $(hostname) == *.bosccluster.com ]]; then
+            echo "cluster=node" >> "$GITHUB_OUTPUT"
+          else
+            echo "cluster=open" >> "$GITHUB_OUTPUT"
+          fi
+
+  emu-xsai-isa-ame:
+    runs-on:
+      - bosc
+      - ${{ needs.build-xsai-emu.outputs.cluster }}
+    needs: build-xsai-emu
+    continue-on-error: false
+    timeout-minutes: 900
+    name: EMU - XSAI ISA and AME
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: set env
+        run: |
+          JOB_HOME="${CI_HOME}/basics/isa-ame"
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
+          echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
+          echo "PERF_HOME=${JOB_HOME}" >> $GITHUB_ENV
+          echo "WAVE_HOME=${JOB_HOME}" >> $GITHUB_ENV
+          echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
+          mkdir -p "${JOB_HOME}"
+      - name: Initialize submodules
+        run: make init-force
+      - name: clean up
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+      - name: Get artifact
+        run: |
+          mkdir -p build
+          cp -L "${EMU_HOME}/emu" "${GITHUB_WORKSPACE}/build/emu"
       - name: Basic Test - cputest
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --ci cputest 2> /dev/zero
@@ -142,39 +183,143 @@ jobs:
       - name: Basic AME Test
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci ame-tests 2> /dev/zero
+
+  emu-xsai-hypervisor:
+    runs-on:
+      - bosc
+      - ${{ needs.build-xsai-emu.outputs.cluster }}
+    needs: build-xsai-emu
+    continue-on-error: false
+    timeout-minutes: 900
+    name: EMU - XSAI Hypervisor
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: set env
+        run: |
+          JOB_HOME="${CI_HOME}/basics/hypervisor"
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
+          echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
+          echo "PERF_HOME=${JOB_HOME}" >> $GITHUB_ENV
+          echo "WAVE_HOME=${JOB_HOME}" >> $GITHUB_ENV
+          echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
+          mkdir -p "${JOB_HOME}"
+      - name: Initialize submodules
+        run: make init-force
+      - name: clean up
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+      - name: Get artifact
+        run: |
+          mkdir -p build
+          cp -L "${EMU_HOME}/emu" "${GITHUB_WORKSPACE}/build/emu"
       - name: Extension Test - hypervisor
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci rvh-tests 2> /dev/zero
+
+  emu-xsai-system:
+    runs-on:
+      - bosc
+      - ${{ needs.build-xsai-emu.outputs.cluster }}
+    needs: build-xsai-emu
+    continue-on-error: false
+    timeout-minutes: 900
+    name: EMU - XSAI Microbench, CoreMark, and Linux
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: set env
+        run: |
+          JOB_HOME="${CI_HOME}/basics/system"
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
+          echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
+          echo "PERF_HOME=${JOB_HOME}" >> $GITHUB_ENV
+          echo "WAVE_HOME=${JOB_HOME}" >> $GITHUB_ENV
+          echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
+          mkdir -p "${JOB_HOME}"
+          : > "${JOB_HOME}/microbench.ipc"
+          : > "${JOB_HOME}/coremark.ipc"
+          : > "${JOB_HOME}/linux.ipc"
+      - name: Initialize submodules
+        run: make init-force
+      - name: clean up
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+      - name: Get artifact
+        run: |
+          mkdir -p build
+          cp -L "${EMU_HOME}/emu" "${GITHUB_WORKSPACE}/build/emu"
       - name: Simple Test - microbench
-        id: microbench
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --ci microbench 2> perf.log | tee stdout.log
           cat perf.log | sort | tee $PERF_HOME/microbench.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
+          IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log || true)
+          printf '%s\n' "${IPC:-N/A}" | tee "$PERF_HOME/microbench.ipc"
       - name: Simple Test - CoreMark
-        id: coremark
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci coremark 2> perf.log | tee stdout.log
           cat perf.log | sort | tee $PERF_HOME/coremark.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
+          IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log || true)
+          printf '%s\n' "${IPC:-N/A}" | tee "$PERF_HOME/coremark.ipc"
       - name: System Test - Linux
-        id: linux
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci linux-hello-opensbi 2> perf.log | tee stdout.log
           cat perf.log | sort | tee $PERF_HOME/linux.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
+          IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log || true)
+          printf '%s\n' "${IPC:-N/A}" | tee "$PERF_HOME/linux.ipc"
+
+  emu-xsai-extensions:
+    runs-on:
+      - bosc
+      - ${{ needs.build-xsai-emu.outputs.cluster }}
+    needs: build-xsai-emu
+    continue-on-error: false
+    timeout-minutes: 900
+    name: EMU - XSAI Other Extensions
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: set env
+        run: |
+          JOB_HOME="${CI_HOME}/basics/extensions"
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
+          echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
+          echo "PERF_HOME=${JOB_HOME}" >> $GITHUB_ENV
+          echo "WAVE_HOME=${JOB_HOME}" >> $GITHUB_ENV
+          echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
+          mkdir -p "${JOB_HOME}"
+          : > "${JOB_HOME}/povray.ipc"
+          : > "${JOB_HOME}/copy_and_run.ipc"
+      - name: Initialize submodules
+        run: make init-force
+      - name: clean up
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+      - name: Get artifact
+        run: |
+          mkdir -p build
+          cp -L "${EMU_HOME}/emu" "${GITHUB_WORKSPACE}/build/emu"
       - name: Floating-point Test - povray
-        id: povray
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --max-instr 5000000 --ci povray --gcpt-restore-bin $GCPT_RESTORE_BIN 2> perf.log | tee stdout.log
           cat perf.log | sort | tee $PERF_HOME/povray.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
+          IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log || true)
+          printf '%s\n' "${IPC:-N/A}" | tee "$PERF_HOME/povray.ipc"
       - name: Uncache Fetch Test - copy and run
-        id: copy_and_run
         run: |
           $GITHUB_WORKSPACE/build/emu  -F $GITHUB_WORKSPACE/ready-to-run/copy_and_run.bin -i $GITHUB_WORKSPACE/ready-to-run/microbench.bin --diff $GITHUB_WORKSPACE/ready-to-run/riscv64-nemu-interpreter-so --enable-fork 2> perf.log | tee stdout.log
           cat perf.log | sort | tee $PERF_HOME/copy_and_run.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
+          IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log || true)
+          printf '%s\n' "${IPC:-N/A}" | tee "$PERF_HOME/copy_and_run.ipc"
       - name: VFEXP2 Extension Test - vfexp2test
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci vfexp2test 2> /dev/zero
@@ -187,17 +332,59 @@ jobs:
       - name: Zcb Extension Test - zcb-test
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci zcb-test 2> /dev/zero
+
+  emu-xsai-basics:
+    runs-on:
+      - bosc
+      - ${{ needs.build-xsai-emu.outputs.cluster }}
+    needs:
+      - build-xsai-emu
+      - emu-xsai-isa-ame
+      - emu-xsai-hypervisor
+      - emu-xsai-system
+      - emu-xsai-extensions
+    if: ${{ always() && needs.build-xsai-emu.result == 'success' }}
+    continue-on-error: false
+    timeout-minutes: 30
+    name: EMU - XSAI Basics
+    steps:
       - name: Generate summary
-        if: always()
+        shell: bash
         run: |
-          echo "## Emu - Basics summary" >> $GITHUB_STEP_SUMMARY
-          echo "| Testcase | IPC |" >> $GITHUB_STEP_SUMMARY
-          echo "| -------- | --- |" >> $GITHUB_STEP_SUMMARY
-          echo "| microbench | ${{ steps.microbench.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| coremark | ${{ steps.coremark.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| linux | ${{ steps.linux.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| povray | ${{ steps.povray.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| copy_and_run | ${{ steps.copy_and_run.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
+          write_ipc_row() {
+            local testcase="$1"
+            local ipc_file="$2"
+            local ipc="N/A"
+            if [[ -s "${ipc_file}" ]]; then
+              ipc=$(head -n 1 "${ipc_file}")
+            fi
+            echo "| ${testcase} | ${ipc} |"
+          }
+
+          {
+            echo "## Emu - Basics summary"
+            echo "| Testcase | IPC |"
+            echo "| -------- | --- |"
+            write_ipc_row microbench "${CI_HOME}/basics/system/microbench.ipc"
+            write_ipc_row coremark "${CI_HOME}/basics/system/coremark.ipc"
+            write_ipc_row linux "${CI_HOME}/basics/system/linux.ipc"
+            write_ipc_row povray "${CI_HOME}/basics/extensions/povray.ipc"
+            write_ipc_row copy_and_run "${CI_HOME}/basics/extensions/copy_and_run.ipc"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Check test jobs
+        env:
+          ISA_AME_RESULT: ${{ needs.emu-xsai-isa-ame.result }}
+          HYPERVISOR_RESULT: ${{ needs.emu-xsai-hypervisor.result }}
+          SYSTEM_RESULT: ${{ needs.emu-xsai-system.result }}
+          EXTENSIONS_RESULT: ${{ needs.emu-xsai-extensions.result }}
+        run: |
+          if [[ "$ISA_AME_RESULT" != "success" || \
+                "$HYPERVISOR_RESULT" != "success" || \
+                "$SYSTEM_RESULT" != "success" || \
+                "$EXTENSIONS_RESULT" != "success" ]]; then
+            echo "One or more XSAI test jobs failed or were cancelled."
+            exit 1
+          fi
 
   docker-build:
     name: Docker Build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,10 +60,13 @@ jobs:
       - ${{ needs.build-default-matrix.outputs.cluster }} # use the same cluster as the builder
     needs: build-default-matrix
     continue-on-error: false
-    # At most 12 hours after the shared EMU build completes.
     timeout-minutes: 720
-    # 8 checkpoints * 1-hour timeout, plus setup time.
-    name: Nightly Regression(master) - Checkpoints
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        checkpoint: [0, 1, 2, 3, 4, 5, 6, 7]
+    name: Nightly Regression(master) - Checkpoint ${{ matrix.checkpoint }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -71,7 +74,7 @@ jobs:
           submodules: true
       - name: set env
         run: |
-          JOB_HOME="${NIGHTLY_HOME}/checkpoints"
+          JOB_HOME="${NIGHTLY_HOME}/checkpoints/random-${{ matrix.checkpoint }}"
           echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "PERF_HOME=${JOB_HOME}" >> $GITHUB_ENV
@@ -87,70 +90,14 @@ jobs:
         run: |
           mkdir -p build
           cp -L ${EMU_HOME}/emu ${GITHUB_WORKSPACE}/build/emu
-      - name: Random Checkpoint 0
+      - name: Random Checkpoint ${{ matrix.checkpoint }}
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
             --wave-dump $WAVE_HOME --threads 16 --numa             \
             --ci random --timeout 3600 --ram-size=16GB             \
             --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
             2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_0.txt
-      - name: Random Checkpoint 1
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
-            --wave-dump $WAVE_HOME --threads 16 --numa             \
-            --ci random --timeout 3600 --ram-size=16GB             \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
-            2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_1.txt
-      - name: Random Checkpoint 2
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
-            --wave-dump $WAVE_HOME --threads 16 --numa             \
-            --ci random --timeout 3600 --ram-size=16GB             \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
-            2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_2.txt
-      - name: Random Checkpoint 3
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
-            --wave-dump $WAVE_HOME --threads 16 --numa             \
-            --ci random --timeout 3600 --ram-size=16GB             \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
-            2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_3.txt
-      - name: Random Checkpoint 4
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
-            --wave-dump $WAVE_HOME --threads 16 --numa             \
-            --ci random --timeout 3600 --ram-size=16GB             \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
-            2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_4.txt
-      - name: Random Checkpoint 5
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
-            --wave-dump $WAVE_HOME --threads 16 --numa             \
-            --ci random --timeout 3600 --ram-size=16GB             \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
-            2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_5.txt
-      - name: Random Checkpoint 6
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
-            --wave-dump $WAVE_HOME --threads 16 --numa             \
-            --ci random --timeout 3600 --ram-size=16GB             \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
-            2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_6.txt
-      - name: Random Checkpoint 7
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
-            --wave-dump $WAVE_HOME --threads 16 --numa             \
-            --ci random --timeout 3600 --ram-size=16GB             \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
-            2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_7.txt
+          cat perf.log | sort | tee $PERF_HOME/random_${{ matrix.checkpoint }}.txt
 
   emu-xsai-performance:
     runs-on:
@@ -159,7 +106,32 @@ jobs:
     needs: build-default-matrix
     continue-on-error: false
     timeout-minutes: 720
-    name: EMU - XSAI General-Purpose Performance
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        include:
+          - benchmark: hmmer-Vector
+            use_gcpt_restore_patch: false
+          - benchmark: mcf
+            use_gcpt_restore_patch: true
+          - benchmark: xalancbmk
+            use_gcpt_restore_patch: true
+          - benchmark: gcc
+            use_gcpt_restore_patch: true
+          - benchmark: namd
+            use_gcpt_restore_patch: true
+          - benchmark: milc
+            use_gcpt_restore_patch: true
+          - benchmark: lbm
+            use_gcpt_restore_patch: true
+          - benchmark: gromacs
+            use_gcpt_restore_patch: true
+          - benchmark: wrf
+            use_gcpt_restore_patch: true
+          - benchmark: astar
+            use_gcpt_restore_patch: true
+    name: EMU - XSAI Performance - ${{ matrix.benchmark }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -167,7 +139,7 @@ jobs:
           submodules: true
       - name: set env
         run: |
-          JOB_HOME="${NIGHTLY_HOME}/performance"
+          JOB_HOME="${NIGHTLY_HOME}/performance/${{ matrix.benchmark }}"
           echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
@@ -175,6 +147,7 @@ jobs:
           echo "WAVE_HOME=${JOB_HOME}" >> $GITHUB_ENV
           echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
           mkdir -p "${JOB_HOME}"
+          : > "${JOB_HOME}/ipc.txt"
       - name: Initialize submodules
         run: make init-force
       - name: clean up
@@ -184,121 +157,53 @@ jobs:
         run: |
           mkdir -p build
           cp -L ${EMU_HOME}/emu ${GITHUB_WORKSPACE}/build/emu
-      - name: SPEC06 Test - hmmer-Vector
-        id: hmmer_vector
+      - name: SPEC06 Test - ${{ matrix.benchmark }}
+        id: run
+        shell: bash
         run: |
+          RESTORE_ARGS=()
+          if [[ "${{ matrix.use_gcpt_restore_patch }}" == "true" ]]; then
+            RESTORE_ARGS=(--gcpt-restore-bin "$GCPT_RESTORE_BIN")
+          fi
+
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
             --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci hmmer-Vector                                   \
+            --numa --ci "${{ matrix.benchmark }}"                      \
+            "${RESTORE_ARGS[@]}"                                      \
             2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/hmmer-Vector.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - mcf
-        id: mcf
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci mcf                                           \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/mcf.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - xalancbmk
-        id: xalancbmk
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci xalancbmk                                     \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/xalancbmk.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - gcc
-        id: gcc
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci gcc                                           \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/gcc.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - namd
-        id: namd
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci namd                                          \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/namd.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - milc
-        id: milc
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci milc                                          \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/milc.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - lbm
-        id: lbm
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci lbm                                           \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/lbm.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - gromacs
-        id: gromacs
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci gromacs                                       \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/gromacs.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - wrf
-        id: wrf
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci wrf                                           \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/wrf.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
-      - name: SPEC06 Test - astar
-        id: astar
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py               \
-            --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000   \
-            --numa --ci astar                                         \
-            --gcpt-restore-bin $GCPT_RESTORE_BIN                       \
-            2> perf.log | tee stdout.log
-          cat perf.log | sort | tee $PERF_HOME/astar.log
-          echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
+          cat perf.log | sort | tee "$PERF_HOME/${{ matrix.benchmark }}.log"
+          IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log || true)
+          printf '%s\n' "${IPC:-N/A}" | tee "$PERF_HOME/ipc.txt"
+
+  emu-xsai-performance-summary:
+    runs-on:
+      - bosc
+      - ${{ needs.build-default-matrix.outputs.cluster }}
+    needs:
+      - build-default-matrix
+      - emu-xsai-performance
+    if: ${{ always() && needs.build-default-matrix.result == 'success' }}
+    timeout-minutes: 30
+    name: EMU - XSAI Performance Summary
+    steps:
       - name: Generate summary
-        if: always()
         run: |
-          echo "## Emu - Performance summary" >> $GITHUB_STEP_SUMMARY
-          echo "| Testcase | IPC |" >> $GITHUB_STEP_SUMMARY
-          echo "| -------- | --- |" >> $GITHUB_STEP_SUMMARY
-          echo "| hmmer-Vector | ${{ steps.hmmer_vector.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| mcf | ${{ steps.mcf.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| xalancbmk | ${{ steps.xalancbmk.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| gcc | ${{ steps.gcc.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| namd | ${{ steps.namd.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| milc | ${{ steps.milc.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| lbm | ${{ steps.lbm.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| gromacs | ${{ steps.gromacs.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| wrf | ${{ steps.wrf.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| astar | ${{ steps.astar.outputs.IPC }} |" >> $GITHUB_STEP_SUMMARY
+          RESULTS_HOME="${NIGHTLY_HOME}/performance"
+          BENCHMARKS=(hmmer-Vector mcf xalancbmk gcc namd milc lbm gromacs wrf astar)
+
+          {
+            echo "## Emu - Performance summary"
+            echo "| Testcase | IPC |"
+            echo "| -------- | --- |"
+            for benchmark in "${BENCHMARKS[@]}"; do
+              IPC_FILE="${RESULTS_HOME}/${benchmark}/ipc.txt"
+              IPC="N/A"
+              if [[ -s "${IPC_FILE}" ]]; then
+                IPC=$(head -n 1 "${IPC_FILE}")
+              fi
+              echo "| ${benchmark} | ${IPC} |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
 
   emu-no-matrix:
     runs-on: bosc


### PR DESCRIPTION
Reuse shared DefaultMatrixConfig emulators on runners from the builder's cluster. Split EMU basics into four balanced jobs, and fan out eight nightly checkpoint runs and ten SPEC06 workloads.

Isolate NFS outputs per job, preserve IPC summaries, and retain the aggregate failure gate.