### PR TITLE
fix(rob): prevent interrupts for msetcfg

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1250,6 +1250,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
                              !FuType.isFence(io.enq.req(i).bits.fuType) &&
                              !FuType.isCsr(io.enq.req(i).bits.fuType) &&
                              !io.enq.req(i).bits.isVset &&
+                             !io.enq.req(i).bits.isMsetcfg &&
                              !FuType.isAMO(io.enq.req(i).bits.fuType)
       robEntries(allocatePtrVec(i).value).interrupt_safe := allow_interrupts
     }


### PR DESCRIPTION
This PR fixes a bug that can be reliably triggered by msetcfg, which simultaneously sets both flushPipe and interrupt_safe.

The issue requires an instruction to retain flushPipe while also being marked as interrupt_safe. msetcfg naturally satisfies this condition, making the bug reproducible.