### PR TITLE
feat(rob): add Palladium commit-stall watchdog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ endif
 # emu for the release version
 RELEASE_ARGS += --fpga-platform --disable-all --remove-assert --reset-gen --firtool-opt --ignore-read-enable-mem
 ifeq ($(FPGA), 1)
-override DEBUG_ARGS	+= --fpga-platform --disable-all --remove-assert --disable-clockgate
+override DEBUG_ARGS	+= --fpga-platform --disable-all --remove-assert --disable-clockgate --sim-mem-size 8
 else
 override DEBUG_ARGS	+= --enable-difftest
 endif

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -998,7 +998,8 @@ trait HasXSParameter {
   def numCSRPCntHc       = 5
   def printEventCoding   = true
   def printCriticalError = false
-  def maxCommitStuck = pow(2, 15).toInt
+  def maxCommitStuck = pow(2, 21).toInt
+  def maxCommitStuckDebug = pow(2, 16).toInt
 
   // Vector load exception
   def maxMergeNumPerCycle = 4

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -998,7 +998,7 @@ trait HasXSParameter {
   def numCSRPCntHc       = 5
   def printEventCoding   = true
   def printCriticalError = false
-  def maxCommitStuck = pow(2, 21).toInt
+  def maxCommitStuck = pow(2, 15).toInt
 
   // Vector load exception
   def maxMergeNumPerCycle = 4

--- a/src/main/scala/xiangshan/backend/rob/CommitStuckCounter.scala
+++ b/src/main/scala/xiangshan/backend/rob/CommitStuckCounter.scala
@@ -1,0 +1,82 @@
+package xiangshan.backend.rob
+
+import chisel3._
+import chisel3.util.HasBlackBoxInline
+
+class CommitStuckFinish(width: Int, timeout: Int) extends BlackBox with HasBlackBoxInline {
+  val io = IO(new Bundle {
+    val clock = Input(Clock())
+    val reset = Input(Bool())
+    val stuck = Input(Bool())
+    val fired = Output(Bool())
+  })
+
+  require(width > 0, "commit-stuck watchdog width must be positive")
+  require(timeout > 0, "commit-stuck watchdog timeout must be positive")
+
+  setInline("CommitStuckFinish.sv",
+    s"""
+       |module CommitStuckFinish #(
+       |  parameter integer TIMEOUT = $timeout
+       |) (
+       |  input  clock,
+       |  input  reset,
+       |  input  stuck,
+       |  output fired
+       |);
+       |`ifdef PALLADIUM
+       |  reg [${width - 1}:0] count;
+       |  reg fired_reg;
+       |
+       |  assign fired = fired_reg;
+       |
+       |  always @(posedge clock) begin
+       |    if (reset) begin
+       |      count     <= '0;
+       |      fired_reg <= 1'b0;
+       |    end
+       |    else if (!stuck) begin
+       |      count     <= '0;
+       |      fired_reg <= 1'b0;
+       |    end
+       |    else if (!fired_reg) begin
+       |      if (count == TIMEOUT - 1) begin
+       |        $$display("Commit stuck for %0d cycles; finishing simulation", TIMEOUT);
+       |        $$finish;
+       |        fired_reg <= 1'b1;
+       |      end
+       |      else begin
+       |        count <= count + 1'b1;
+       |      end
+       |    end
+       |  end
+       |`else
+       |  assign fired = 1'b0;
+       |`endif // PALLADIUM
+       |endmodule
+       |""".stripMargin
+  )
+}
+
+
+class CommitStuckCounter(width: Int, forceEnable: Bool) extends Module {
+  val io = IO(new Bundle {
+    val stuck = Input(Bool())
+    val runtimeEnable = Input(Bool())
+    val overflowEnabled = Input(Bool())
+    val count = Output(UInt(width.W))
+    val overflow = Output(Bool())
+  })
+
+  private val count = RegInit(0.U(width.W))
+  private val effectiveEnable = io.runtimeEnable || forceEnable
+
+  when (!effectiveEnable || !io.stuck) {
+    count := 0.U
+  }.otherwise {
+    count := count + 1.U
+  }
+
+  io.count := count
+  io.overflow := count.andR && io.overflowEnabled
+}

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1825,6 +1825,15 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   )
   generateCriticalErrors()
 
+  // Keep a Palladium watchdog independent of difftest and Chisel assertions.
+  // `commitStuck` excludes MMIO and WFI cases that are allowed to make no
+  // forward progress, so only a genuine commit stall reaches the watchdog.
+  val commitStuckFinish = Module(new CommitStuckFinish(log2Up(maxCommitStuck), maxCommitStuck))
+  commitStuckFinish.io.clock := clock
+  commitStuckFinish.io.reset := reset.asBool
+  commitStuckFinish.io.stuck := commitStuck
+  dontTouch(commitStuckFinish.io.fired)
+
 
   // dontTouch for debug
   if (backendParams.debugEn) {

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1828,7 +1828,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   // Keep a Palladium watchdog independent of difftest and Chisel assertions.
   // `commitStuck` excludes MMIO and WFI cases that are allowed to make no
   // forward progress, so only a genuine commit stall reaches the watchdog.
-  val commitStuckFinish = Module(new CommitStuckFinish(log2Up(maxCommitStuck), maxCommitStuck))
+  val commitStuckFinish = Module(new CommitStuckFinish(log2Up(maxCommitStuckDebug), maxCommitStuckDebug))
   commitStuckFinish.io.clock := clock
   commitStuckFinish.io.reset := reset.asBool
   commitStuckFinish.io.stuck := commitStuck


### PR DESCRIPTION
Add a Palladium-visible watchdog that terminates simulation after a sustained ROB commit stall, and shorten the detection threshold for faster failure reporting. Constrain PLDM debug simulation memory to 8 GiB.