### PR TITLE
ci: update nightly regression checkpoint pools

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,7 +79,7 @@ jobs:
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "PERF_HOME=${JOB_HOME}" >> $GITHUB_ENV
           echo "WAVE_HOME=${JOB_HOME}" >> $GITHUB_ENV
-          echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
+          echo "GCPT_RESTORE_BIN=/nfs/home/share/checkpoints_profiles/spec06_gcc16_rv64gcb_260819/gcpt/gcpt.bin" >> $GITHUB_ENV
           mkdir -p "${JOB_HOME}"
       - name: Initialize submodules
         run: make init-force
@@ -92,12 +92,13 @@ jobs:
           cp -L ${EMU_HOME}/emu ${GITHUB_WORKSPACE}/build/emu
       - name: Random Checkpoint ${{ matrix.checkpoint }}
         run: |
+          PERF_LOG="$PERF_HOME/random_${{ matrix.checkpoint }}.txt"
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \
             --wave-dump $WAVE_HOME --threads 16 --numa             \
             --ci random --timeout 3600 --ram-size=16GB             \
             --gcpt-restore-bin $GCPT_RESTORE_BIN                   \
-            2> perf.log
-          cat perf.log | sort | tee $PERF_HOME/random_${{ matrix.checkpoint }}.txt
+            2> >(tee "$PERF_LOG" >&2)
+          sort -o "$PERF_LOG" "$PERF_LOG"
 
   emu-xsai-performance:
     runs-on:

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -565,10 +565,15 @@ class XiangShan(object):
         # select a random SPEC checkpoint
         assert(name == "random")
         all_cpt_dir = [
-            "/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_o3_20m/take_cpt",
-            "/nfs/home/share/checkpoints_profiles/spec17_rv64gcb_o3_20m/take_cpt"
+            "/nfs/home/share/checkpoints_profiles/spec06_gcc16_rv64gcb_260819/checkpoint",
+            "/nfs/home/share/checkpoints_profiles/spec17_rate_gcc16_rv64gcb_260812/checkpoint"
         ]
+        missing_cpt_dir = [path for path in all_cpt_dir if not os.path.isdir(path)]
+        if missing_cpt_dir:
+            raise FileNotFoundError(f"Checkpoint pool directories not found: {missing_cpt_dir}")
         all_gcpt = load_all_gcpt(all_cpt_dir)
+        if not all_gcpt:
+            raise RuntimeError(f"No checkpoint images found under: {all_cpt_dir}")
         return [random.choice(all_gcpt)]
 
     def run_ci(self, test):


### PR DESCRIPTION
Use the current single-core RV64GCB GCC16 checkpoint pools for SPEC CPU2006 and CPU2017, together with their compatible GCPT restorer.

Preserve random-checkpoint stderr in the nightly result directory and report missing or empty checkpoint pools explicitly.