### PR TITLE
fix(sync): synchronize latest(260904) kunminghu-v2 bug fixes into XSAI

### DIFF
--- a/src/main/scala/device/AXI4Memory.scala
+++ b/src/main/scala/device/AXI4Memory.scala
@@ -70,11 +70,18 @@ class MemoryRequestHelper(requestType: Int)
     "  input             io_req_valid,",
     "  input      [63:0] io_req_bits_addr,",
     "  input      [31:0] io_req_bits_id,",
-    "  output            io_response",
+    "  output reg        io_response",
     ");",
     "",
-    " assign io_response = (reset ? 1'b0 :",
-    "               (io_req_valid ? memory_request(io_req_bits_addr, io_req_bits_id, REQUEST_TYPE) : 1'b0));",
+    "always @(negedge clock or posedge reset) begin",
+    "  if (reset) begin",
+    "    io_response <= 1'b0;",
+    "  end else if (io_req_valid) begin",
+    "    io_response <= memory_request(io_req_bits_addr, io_req_bits_id, REQUEST_TYPE);",
+    "  end else begin",
+    "    io_response <= 1'b0;",
+    "  end",
+    "end",
     "endmodule"
   )
   setInline(s"$desiredName.v", verilogLines.mkString("\n"))
@@ -116,11 +123,18 @@ class MemoryResponseHelper(requestType: Int)
     "  input             clock,",
     "  input             reset,",
     "  input             enable,",
-    "  output [63:0]     response",
+    "  output reg [63:0] response",
     ");",
     "",
-    "assign response = reset ? 64'b0 :",
-    "((!reset && enable) ? memory_response(REQUEST_TYPE) : 64'b0);",
+    "always @(negedge clock or posedge reset) begin",
+    "  if (reset) begin",
+    "    response <= 64'b0;",
+    "  end else if (enable) begin",
+    "    response <= memory_response(REQUEST_TYPE);",
+    "  end else begin",
+    "    response <= 64'b0;",
+    "  end",
+    "end",
     "endmodule"
   )
   setInline(s"$desiredName.v", verilogLines.mkString("\n"))

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/Debug.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/Debug.scala
@@ -306,12 +306,19 @@ class MemTrigger(memType: Boolean = MemType.LOAD)(override implicit val p: Param
   }
 
   def DcacheLineBitsEq(): (Bool, Vec[Bool])= {
+    val cacheLineBase = Cat(vaddr(VAddrBits - 1, DCacheLineOffset), 0.U(DCacheLineOffset.W))
+    val cacheLineLast = Cat(vaddr(VAddrBits - 1, DCacheLineOffset), Fill(DCacheLineOffset, 1.U(1.W)))
     (
     io.isCbo.getOrElse(false.B),
     VecInit(tdataVec.zip(tEnableVec).map{ case(tdata, en) =>
+      val tdata2 = tdata.tdata2(VAddrBits - 1, 0)
+      val cacheLineMatch = MuxLookup(tdata.matchType, false.B)(Seq(
+        TrigMatchEnum.EQ -> (vaddr(VAddrBits - 1, DCacheLineOffset) === tdata2(VAddrBits - 1, DCacheLineOffset)),
+        TrigMatchEnum.GE -> (cacheLineLast >= tdata2),
+        TrigMatchEnum.LT -> (cacheLineBase < tdata2)
+      ))
       !tdata.select && !debugMode && en &&
-        tdata.store && io.isCbo.getOrElse(false.B) &&
-        (vaddr >> DCacheLineOffset) === (tdata.tdata2 >> DCacheLineOffset)
+        tdata.store && io.isCbo.getOrElse(false.B) && cacheLineMatch
     })
     )
   }

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1134,7 +1134,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   loadTrigger.io.fromCsrTrigger.tEnableVec           := io.fromCsrTrigger.tEnableVec
   loadTrigger.io.fromCsrTrigger.triggerCanRaiseBpExp := io.fromCsrTrigger.triggerCanRaiseBpExp
   loadTrigger.io.fromCsrTrigger.debugMode            := io.fromCsrTrigger.debugMode
-  loadTrigger.io.fromLoadStore.vaddr                 := s1_vaddr
+  loadTrigger.io.fromLoadStore.vaddr                 := s1_out.fullva
   loadTrigger.io.fromLoadStore.isVectorUnitStride    := s1_in.isvec && s1_in.is128bit
   loadTrigger.io.fromLoadStore.mask                  := s1_in.mask
   loadTrigger.io.isPrf.get                           := s1_prf

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -343,7 +343,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   storeTrigger.io.fromCsrTrigger.tEnableVec           := io.fromCsrTrigger.tEnableVec
   storeTrigger.io.fromCsrTrigger.triggerCanRaiseBpExp := io.fromCsrTrigger.triggerCanRaiseBpExp
   storeTrigger.io.fromCsrTrigger.debugMode            := io.fromCsrTrigger.debugMode
-  storeTrigger.io.fromLoadStore.vaddr                 := s1_in.vaddr
+  storeTrigger.io.fromLoadStore.vaddr                 := s1_fullva
   storeTrigger.io.fromLoadStore.isVectorUnitStride    := s1_in.isvec && s1_in.is128bit
   storeTrigger.io.fromLoadStore.mask                  := s1_in.mask
   storeTrigger.io.isCbo.get                           := s1_isCbo

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -209,7 +209,7 @@ class FeedbackToLsqIO(implicit p: Parameters) extends VLSUBundle{
   val lqIdx = new LqPtr
   val vaddr = UInt(XLEN.W)
   val vaNeedExt = Bool()
-  val gpaddr = UInt(GPAddrBits.W)
+  val gpaddr = UInt(XLEN.W)
   val isForVSnonLeafPTE = Bool()
   val feedback = Vec(VecFeedbacks.allFeedbacks, Bool())
     // for exception

--- a/src/main/scala/xiangshan/mem/vector/VecCommon.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecCommon.scala
@@ -301,7 +301,7 @@ class VecMemExuOutput(isVector: Boolean = false)(implicit p: Parameters) extends
   val mask        = UInt(VLENB.W)
   val vaddr       = UInt(XLEN.W)
   val vaNeedExt   = Bool()
-  val gpaddr      = UInt(GPAddrBits.W)
+  val gpaddr      = UInt(XLEN.W)
   val isForVSnonLeafPTE = Bool()
   val vecTriggerMask = UInt((VLEN/8).W)
 }


### PR DESCRIPTION
## Summary

Synchronize four applicable bug fixes from XiangShan `kunminghu-v2` (`5d3934132`) onto XSAI, based on `a3195e630`.

### Applied Upstream Bugfixes

| Upstream kunminghu-v2 | Local XSAI | Summary |
| --- | --- | --- |
| `8fd2746363` | `729fbe8a3` | Preserve full-XLEN vector exception GPA bits for `mtval2`. |
| `130149fc5f` | `a9ba0be28` | Use PMM-normalized virtual addresses for load/store trigger matching. |
| `1fd6f25746` | `256beb492` | Implement CBO LT/GE address-trigger matching. |
| `ec0f8ba029` | `c469ace74` | Sample DRAMSim3 DPI request/response calls at stable falling-edge phases. |

All commits preserve the upstream author and include a `(cherry picked from commit <upstream-sha>)` trailer.

### Context Adaptation

`ec0f8ba029` conflicted in `AXI4Memory.scala`. The resolution retains the upstream falling-edge registered DPI behavior while preserving XSAI-local wrapper/context code. No additional functional behavior was introduced.

### Excluded Updates

- `5d3fe8d1e` depends on the upstream vector partial-replay mechanism, which XSAI replaced with its own whole-UOP replay protocol.
- `5d3934132` has an already-covered StoreEvent RTL portion (`1e523d646`); its remaining changes are difftest/ready-to-run integration.
- `3aedca94c`, `0fa7bb825`, and `80745e0ea` are features.
- `0d7aaa20a`, `899075424`, and `485333f4d` are compatibility integration updates rather than standalone XSAI RTL bug fixes.

### Validation

`make xsai` was run exactly once and completed successfully.

- `ame-gemm`: `HIT GOOD TRAP`, IPC `1.892391`.
- `ame-ls-ab`: all Load A/B cases passed, IPC `3.743254`.
- `ame-ls-whole` (the no-tile-load CI variant): `HIT GOOD TRAP`, IPC `3.099987`.
- Scalar LR/SC/AMO trigger regression: passed.
- CBO LT/GE trigger regression: all four boundaries passed. The pre-sync baseline fails the intended GE/LT cases.
- PMM-normalized trigger regression: load and store both raise breakpoint (`mcause=3`); the pre-sync baseline returns `mcause=0` for both.